### PR TITLE
Exempt room view from X-Frame-Options

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -58,5 +58,6 @@ class ListEventsView(APIView):
         return paginator.get_paginated_response(serializer.data)
 
 
+@xframe_options_exempt
 def room(request, room_name):
     return render(request, 'show_events.html', {"room": room_name})


### PR DESCRIPTION
If this is a terrible idea, feel free to close the PR. I was thinking of including a room in an iframe for the lobby screen we were discussing the other day.