### PR TITLE
Import xframe_options_exempt

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -4,6 +4,7 @@ import requests
 from channels import Group
 from django.conf import settings
 from django.shortcuts import render
+from django.views.decorators.clickjacking import xframe_options_exempt
 from rest_framework import status, serializers
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import IsAuthenticated, IsAdminUser


### PR DESCRIPTION
Whoops. https://stackoverflow.com/a/25970979/4074877 claims you also need to `from django.http import HttpResponse` but I don't think that's true here.