### PR TITLE
Allow client to specify text size

### DIFF
--- a/main/templates/show_events.html
+++ b/main/templates/show_events.html
@@ -14,7 +14,7 @@
       font-family: monospace;
       color: white;
       text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
-      font-size: 8em;
+      font-size: {{ em }}em;
       padding:0 1em;
     }
   </style>

--- a/main/urls.py
+++ b/main/urls.py
@@ -15,5 +15,6 @@ urlpatterns = [
     path('events', views.ListEventsView.as_view(), name='events'),
     path('endpoints', root_view),
     path('rooms/<room_name>', views.room),
+    path('rooms/<room_name>/<int:em>', views.room),
     path('', views.room, kwargs={"room_name": "display"}),
 ]

--- a/main/views.py
+++ b/main/views.py
@@ -60,5 +60,5 @@ class ListEventsView(APIView):
 
 
 @xframe_options_exempt
-def room(request, room_name):
-    return render(request, 'show_events.html', {"room": room_name})
+def room(request, room_name, em=8):
+    return render(request, 'show_events.html', {"room": room_name, "em": em})


### PR DESCRIPTION
By adding a slash and a number to the end of a room URL, the client can specify the text size in em. The default is 8.